### PR TITLE
Removed contruct_msg_end

### DIFF
--- a/rabo2ofx.py
+++ b/rabo2ofx.py
@@ -436,9 +436,6 @@ class OfxWriter():
                 account_message_end = construct_account_end()
                 ofxfile.write(account_message_end)
 
-            message_end = construct_msg_end()
-            ofxfile.write(message_end)
-
             message_footer = construct_message_footer()
             ofxfile.write(message_footer)
 


### PR DESCRIPTION
Dear gbonnema,

Thanks a lot for sharing this code! 

I want to suggest a tiny change that fixes a bug that caused the output of rabo2ofx to be non-valid XML. The output of contruct_msg_end should not be added to the output file, because for every bank account, this text was already outputted by construct_account_end();

This fix allowed me to use the OFX files also in combination with my bookkeeping program MoneyDance.

Best regards,
Leon van der Graaff